### PR TITLE
Fix crash when tapping only one button

### DIFF
--- a/PDScores/PDScores/bridge_ufb_hand_tooled/features_bta.m
+++ b/PDScores/PDScores/bridge_ufb_hand_tooled/features_bta.m
@@ -50,7 +50,7 @@ void features_bta(PDRealArray *tap, PDRealArray **ft)
     PDRealArray *dx = [tapx diff];
     //i = (abs(dx) > 20);
     PDIntArray *i = [dx applyInt:^size_t(const double element) {
-        return abs(element) > 20;
+        return fabs(element) > 20;
     }];
     //ttx = t(i);
     PDRealArray *ttx = [t elementsWithIndices:[i find]];
@@ -67,6 +67,6 @@ void features_bta(PDRealArray *tap, PDRealArray **ft)
 
     //% Output tapping test feature vector
     //ft = [tapdt tapiqr];
-    (*ft).data[0] = tapdt.data[0];
-    (*ft).data[1] = tapiqr.data[0];
+    (*ft).data[0] = tapdt.data ? tapdt.data[0] : NAN;
+    (*ft).data[1] = tapiqr.data ? tapiqr.data[0] : NAN;
 }


### PR DESCRIPTION
Unfortunately it looks like the whole file changed because I'd changed my Xcode settings to fix line endings on save. Fortunately it still has extra-highlighted the _actual_ changes in the "new" (green) part of the comparison. It's just lines 53, 70, and 71 that have meaningful changes.
